### PR TITLE
OPENSTACK-12: Detach ip in port

### DIFF
--- a/nova_plugin/server.py
+++ b/nova_plugin/server.py
@@ -52,7 +52,8 @@ from openstack_plugin_common import (
     with_neutron_client)
 from nova_plugin.keypair import KEYPAIR_OPENSTACK_TYPE
 from nova_plugin import userdata
-from openstack_plugin_common.floatingip import IP_ADDRESS_PROPERTY
+from openstack_plugin_common.floatingip import (IP_ADDRESS_PROPERTY,
+                                                get_server_floating_ip)
 from neutron_plugin.network import NETWORK_OPENSTACK_TYPE
 from neutron_plugin.port import PORT_OPENSTACK_TYPE
 from cinder_plugin.volume import VOLUME_OPENSTACK_TYPE
@@ -530,16 +531,22 @@ def connect_floatingip(nova_client, fixed_ip, **kwargs):
 
 @operation
 @with_nova_client
-def disconnect_floatingip(nova_client, **kwargs):
+@with_neutron_client
+def disconnect_floatingip(nova_client, neutron_client, **kwargs):
     if is_external_relationship(ctx):
         ctx.logger.info('Not disassociating floatingip and server since '
                         'external floatingip and server are being used')
         return
 
     server_id = ctx.source.instance.runtime_properties[OPENSTACK_ID_PROPERTY]
-    server = nova_client.servers.get(server_id)
-    server.remove_floating_ip(ctx.target.instance.runtime_properties[
-        IP_ADDRESS_PROPERTY])
+    ctx.logger.info("Remove floating ip {0}".format(
+        ctx.target.instance.runtime_properties[IP_ADDRESS_PROPERTY]))
+    server_floating_ip = get_server_floating_ip(neutron_client, server_id)
+    if server_floating_ip:
+        server = nova_client.servers.get(server_id)
+        server.remove_floating_ip(server_floating_ip['floating_ip_address'])
+        ctx.logger.info("Floating ip {0} detached from server"
+                        .format(server_floating_ip['floating_ip_address']))
 
 
 @operation

--- a/openstack_plugin_common/floatingip.py
+++ b/openstack_plugin_common/floatingip.py
@@ -57,3 +57,28 @@ def delete_floatingip(client, **kwargs):
 def floatingip_creation_validation(client, ip_field_name, **kwargs):
     validate_resource(ctx, client, FLOATINGIP_OPENSTACK_TYPE,
                       ip_field_name)
+
+
+def get_server_floating_ip(neutron_client, server_id):
+
+    floating_ips = neutron_client.list_floatingips()
+
+    floating_ips = floating_ips.get('floatingips')
+    if not floating_ips:
+        return None
+
+    for floating_ip in floating_ips:
+        port_id = floating_ip.get('port_id')
+        if not port_id:
+            # this floating ip is not attached to any port
+            continue
+
+        port = neutron_client.show_port(port_id)['port']
+        device_id = port.get('device_id')
+        if not device_id:
+            # this port is not attached to any server
+            continue
+
+        if server_id == device_id:
+            return floating_ip
+    return None


### PR DESCRIPTION
Detach floating IP when we have wrong order of relationships in server node or don't have relationship to floating IP in server node.